### PR TITLE
fix: publish to pypi

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,42 +1,43 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
-name: Python package
+name: Publish to PyPI
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    tags:
+      - 'v*.*.*'  # vから始まるタグ（例: v1.2.3）
 
 jobs:
-  build:
-
+  build-and-publish:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest poetry
-        poetry install
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        poetry install
-        poetry run pytest
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'  # 必要に応じて使用するPythonバージョンを指定
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "${HOME}/.local/bin" >> $GITHUB_PATH
+
+      - name: Configure Poetry
+        run: poetry config virtualenvs.create false
+
+      - name: Set version from Git tag
+        shell: bash
+        run: |
+          TAG=${GITHUB_REF##*/}
+          VERSION=${TAG#v}
+          echo "Detected version: $VERSION"
+          poetry version $VERSION
+
+      - name: Install dependencies and build package
+        run: poetry install && poetry build
+
+      - name: Publish package to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: poetry publish --build --no-interaction --username __token__

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple wrapper of OpenAI for vectorize requests with single request.
 ## Installation
 
 ```bash
-pip install git+https://github.com/anaregdesign/vectorize-openai.git
+pip install openaivec
 ```
 
 ## Uninstall

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [tool.poetry]
 name = "openaivec"
-version = "0.2.1"
+version = "0.0.0"
 description = ""
 authors = ["Hiroki Mizukami <hmizukami@microsoft.com>"]
 license = "MIT License"
 readme = "README.md"
+homepage = "https://github.com/anaregdesign/vectorize-openai"
+repository = "https://github.com/anaregdesign/vectorize-openai"
 packages = [
     { include = "openaivec", from = "." }
 ]
@@ -15,8 +17,14 @@ pandas = "^2.2.3"
 pyspark = "^3.5.1"
 openai = "^1.57.2"
 httpx = {extras = ["http2"], version = "^0.28.1"}
+
+[tool.poetry.dev-dependencies]
 pytest = "^8.3.4"
 
+
+[tool.dynamic-versioning]
+enable = true
+version_pattern = "^v(?P<version>\d+\.\d+\.\d+)$"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This pull request includes significant updates to the CI/CD workflow, package configuration, and documentation. The most important changes include modifying the GitHub Actions workflow to publish to PyPI, updating the installation instructions in the `README.md`, and configuring dynamic versioning in `pyproject.toml`.

### CI/CD Workflow Updates:
* [`.github/workflows/python-package.yml`](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L1-R43): Modified the workflow to publish the package to PyPI when tags are pushed, set up Python and Poetry, configured the version from the Git tag, and added steps to build and publish the package.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8): Updated the installation command to use the package name `openaivec` instead of the GitHub repository URL.

### Package Configuration:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R9): Set the initial version to `0.0.0`, added homepage and repository URLs, and configured dynamic versioning to use the Git tag pattern. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R9) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R20-R28)