### PR TITLE
add: workflow

### DIFF
--- a/.github/workflows/publish-whl.yml
+++ b/.github/workflows/publish-whl.yml
@@ -1,0 +1,40 @@
+name: Build and Upload Wheel
+
+on:
+  release:
+    types: [published]
+
+permissions:
+    contents: write
+    packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python -
+          echo "${HOME}/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: poetry install --no-root
+
+      - name: Build wheel
+        run: poetry build -f wheel
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*.whl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and uploading a Python wheel package upon the publication of a release. The workflow is defined in the `.github/workflows/publish-whl.yml` file.

Key changes include:

* Added a new workflow named "Build and Upload Wheel" that triggers on release publication.
* Configured the workflow to run on `ubuntu-latest` and set up necessary permissions for contents and packages.
* Included steps for checking out the repository, setting up Python 3.10, installing Poetry, installing dependencies, building the wheel, and uploading the release asset.