### PR TITLE
Enforce PEP8 linting using flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E501, W503, E203
+per-file-ignores =
+    __init__.py: F401

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "${HOME}/.local/bin" >> $GITHUB_PATH
+          poetry install --with dev --no-interaction --no-ansi
+
+      - name: Run flake8
+        run: poetry run flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-flake8
+    rev: v3.9.2
+    hooks:
+      - id: flake8

--- a/openaivec/embedding.py
+++ b/openaivec/embedding.py
@@ -13,6 +13,7 @@ __ALL__ = ["EmbeddingOpenAI"]
 
 _logger: Logger = getLogger(__name__)
 
+
 @dataclass(frozen=True)
 class EmbeddingOpenAI:
     client: OpenAI
@@ -20,9 +21,13 @@ class EmbeddingOpenAI:
 
     @observe(_logger)
     def embed(self, sentences: List[str]) -> List[NDArray[np.float32]]:
-        responses = self.client.embeddings.create(input=sentences, model=self.model_name)
+        responses = self.client.embeddings.create(
+            input=sentences, model=self.model_name
+        )
         return [np.array(d.embedding, dtype=np.float32) for d in responses.data]
 
     @observe(_logger)
-    def embed_minibatch(self, sentences: List[str], batch_size: int) -> List[NDArray[np.float32]]:
+    def embed_minibatch(
+        self, sentences: List[str], batch_size: int
+    ) -> List[NDArray[np.float32]]:
         return map_unique_minibatch_parallel(sentences, batch_size, self.embed)

--- a/openaivec/embedding.py
+++ b/openaivec/embedding.py
@@ -21,13 +21,9 @@ class EmbeddingOpenAI:
 
     @observe(_logger)
     def embed(self, sentences: List[str]) -> List[NDArray[np.float32]]:
-        responses = self.client.embeddings.create(
-            input=sentences, model=self.model_name
-        )
+        responses = self.client.embeddings.create(input=sentences, model=self.model_name)
         return [np.array(d.embedding, dtype=np.float32) for d in responses.data]
 
     @observe(_logger)
-    def embed_minibatch(
-        self, sentences: List[str], batch_size: int
-    ) -> List[NDArray[np.float32]]:
+    def embed_minibatch(self, sentences: List[str], batch_size: int) -> List[NDArray[np.float32]]:
         return map_unique_minibatch_parallel(sentences, batch_size, self.embed)

--- a/openaivec/log.py
+++ b/openaivec/log.py
@@ -14,24 +14,32 @@ def observe(logger: Logger):
         def decorated(self: object, *args, **kwargs):
             l: Logger = logger.getChild(self.__class__.__name__).getChild(func.__name__)
             transaction_id: str = str(uuid.uuid4())
-            l.info(json.dumps({
-                "transaction_id": transaction_id,
-                "type": "start",
-                "class": self.__class__.__name__,
-                "method": func.__name__,
-                "logged_at": time.time_ns(),
-            }))
+            l.info(
+                json.dumps(
+                    {
+                        "transaction_id": transaction_id,
+                        "type": "start",
+                        "class": self.__class__.__name__,
+                        "method": func.__name__,
+                        "logged_at": time.time_ns(),
+                    }
+                )
+            )
             try:
                 res = func(self, *args, **kwargs)
 
             finally:
-                l.info(json.dumps({
-                    "transaction_id": transaction_id,
-                    "type": "end",
-                    "class": self.__class__.__name__,
-                    "method": func.__name__,
-                    "logged_at": time.time_ns(),
-                }))
+                l.info(
+                    json.dumps(
+                        {
+                            "transaction_id": transaction_id,
+                            "type": "end",
+                            "class": self.__class__.__name__,
+                            "method": func.__name__,
+                            "logged_at": time.time_ns(),
+                        }
+                    )
+                )
 
             return res
 

--- a/openaivec/spark.py
+++ b/openaivec/spark.py
@@ -64,9 +64,7 @@ class UDFBuilder:
             )
 
             for part in col:
-                yield pd.Series(
-                    client_vec.predict_minibatch(part.tolist(), self.batch_size)
-                )
+                yield pd.Series(client_vec.predict_minibatch(part.tolist(), self.batch_size))
 
         return fn
 
@@ -92,8 +90,6 @@ class UDFBuilder:
             )
 
             for part in col:
-                yield pd.Series(
-                    client_emb.embed_minibatch(part.tolist(), self.batch_size)
-                )
+                yield pd.Series(client_emb.embed_minibatch(part.tolist(), self.batch_size))
 
         return fn

--- a/openaivec/test_spark.py
+++ b/openaivec/test_spark.py
@@ -47,5 +47,5 @@ class TestUDFBuilder(TestCase):
         self.spark.sql(
             """
             SELECT repeat(cast(id as STRING)) as v from dummy
-        """
+            """
         ).show()

--- a/openaivec/test_spark.py
+++ b/openaivec/test_spark.py
@@ -11,18 +11,21 @@ class TestUDFBuilder(TestCase):
         project_root = Path(__file__).parent.parent
         policy_path = project_root / "spark.policy"
         self.udf = UDFBuilder.of_environment(batch_size=8)
-        self.spark: SparkSession = SparkSession.builder \
-            .appName("test") \
-            .master("local[*]") \
-            .config("spark.ui.enabled", "false") \
-            .config("spark.sql.execution.arrow.pyspark.enabled", "true") \
-            .config("spark.driver.extraJavaOptions",
-                    "-Djava.security.manager " +
-                    f"-Djava.security.policy=file://{policy_path} " +
-                    "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED " +
-                    "--add-opens=java.base/java.nio=ALL-UNNAMED " +
-                    "-Darrow.enable_unsafe=true") \
+        self.spark: SparkSession = (
+            SparkSession.builder.appName("test")
+            .master("local[*]")
+            .config("spark.ui.enabled", "false")
+            .config("spark.sql.execution.arrow.pyspark.enabled", "true")
+            .config(
+                "spark.driver.extraJavaOptions",
+                "-Djava.security.manager "
+                + f"-Djava.security.policy=file://{policy_path} "
+                + "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED "
+                + "--add-opens=java.base/java.nio=ALL-UNNAMED "
+                + "-Darrow.enable_unsafe=true",
+            )
             .getOrCreate()
+        )
         self.spark.sparkContext.setLogLevel("INFO")
 
     def tearDown(self):
@@ -30,12 +33,19 @@ class TestUDFBuilder(TestCase):
             self.spark.stop()
 
     def test_completion(self):
-        self.spark.udf.register("repeat", self.udf.completion("""
+        self.spark.udf.register(
+            "repeat",
+            self.udf.completion(
+                """
             Just repeat input string.
-        """))
+        """
+            ),
+        )
         dummy_df = self.spark.range(31)
         dummy_df.createOrReplaceTempView("dummy")
 
-        self.spark.sql("""
+        self.spark.sql(
+            """
             SELECT repeat(cast(id as STRING)) as v from dummy
-        """).show()
+        """
+        ).show()

--- a/openaivec/test_util.py
+++ b/openaivec/test_util.py
@@ -104,6 +104,4 @@ class TestMappingFunctions(TestCase):
         # After applying f: [9, 4, 1]
         # Mapping back for original list: [9, 4, 9, 1]
         expected = [9, 4, 9, 1]
-        self.assertEqual(
-            map_unique_minibatch_parallel(b, batch_size, square_list), expected
-        )
+        self.assertEqual(map_unique_minibatch_parallel(b, batch_size, square_list), expected)

--- a/openaivec/test_util.py
+++ b/openaivec/test_util.py
@@ -1,8 +1,14 @@
 from typing import List
 from unittest import TestCase
 
-from openaivec.util import split_to_minibatch, map_minibatch, map_unique, map_unique_minibatch, \
-    map_unique_minibatch_parallel, map_minibatch_parallel
+from openaivec.util import (
+    split_to_minibatch,
+    map_minibatch,
+    map_unique,
+    map_unique_minibatch,
+    map_unique_minibatch_parallel,
+    map_minibatch_parallel,
+)
 
 
 class TestMappingFunctions(TestCase):
@@ -98,4 +104,6 @@ class TestMappingFunctions(TestCase):
         # After applying f: [9, 4, 1]
         # Mapping back for original list: [9, 4, 9, 1]
         expected = [9, 4, 9, 1]
-        self.assertEqual(map_unique_minibatch_parallel(b, batch_size, square_list), expected)
+        self.assertEqual(
+            map_unique_minibatch_parallel(b, batch_size, square_list), expected
+        )

--- a/openaivec/test_vectorize.py
+++ b/openaivec/test_vectorize.py
@@ -16,9 +16,7 @@ basicConfig(handlers=[_h], level="DEBUG")
 
 def create_dummy_parse(messages: List[Message]) -> ParsedChatCompletion[Response]:
     response = Response(
-        assistant_messages=[
-            Message(id=i, text=f"response_of_{m.text}") for i, m in enumerate(messages)
-        ]
+        assistant_messages=[Message(id=i, text=f"response_of_{m.text}") for i, m in enumerate(messages)]
     )
     dummy_message = SimpleNamespace(parsed=response)
     dummy_choice = SimpleNamespace(message=dummy_message)
@@ -44,9 +42,7 @@ class TestVectorizedOpenAI(TestCase):
         user_messages = ["user_message_{i}" for i in range(7)]
         expected = [f"response_of_{m}" for m in user_messages]
 
-        dummy_completion = create_dummy_parse(
-            [Message(id=i, text=message) for i, message in enumerate(user_messages)]
-        )
+        dummy_completion = create_dummy_parse([Message(id=i, text=message) for i, message in enumerate(user_messages)])
         self.mock_openai.beta.chat.completions.parse.return_value = dummy_completion
 
         actual = self.client.predict(user_messages)

--- a/openaivec/test_vectorize.py
+++ b/openaivec/test_vectorize.py
@@ -11,10 +11,7 @@ from openaivec.vectorize import Message, Response
 
 _h: Handler = StreamHandler()
 
-basicConfig(
-    handlers=[_h],
-    level="DEBUG"
-)
+basicConfig(handlers=[_h], level="DEBUG")
 
 
 def create_dummy_parse(messages: List[Message]) -> ParsedChatCompletion[Response]:
@@ -47,7 +44,9 @@ class TestVectorizedOpenAI(TestCase):
         user_messages = ["user_message_{i}" for i in range(7)]
         expected = [f"response_of_{m}" for m in user_messages]
 
-        dummy_completion = create_dummy_parse([Message(id=i, text=message) for i, message in enumerate(user_messages)])
+        dummy_completion = create_dummy_parse(
+            [Message(id=i, text=message) for i, message in enumerate(user_messages)]
+        )
         self.mock_openai.beta.chat.completions.parse.return_value = dummy_completion
 
         actual = self.client.predict(user_messages)

--- a/openaivec/util.py
+++ b/openaivec/util.py
@@ -5,11 +5,15 @@ from typing import List, TypeVar, Callable
 T = TypeVar("T")
 U = TypeVar("U")
 
+
 def split_to_minibatch(b: List[T], batch_size: int) -> List[List[T]]:
     """Splits the list into sublists of size `batch_size`."""
-    return [b[i:i + batch_size] for i in range(0, len(b), batch_size)]
+    return [b[i : i + batch_size] for i in range(0, len(b), batch_size)]
 
-def map_minibatch(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) -> List[U]:
+
+def map_minibatch(
+    b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]
+) -> List[U]:
     """
     Splits the list `b` into batches of size `batch_size` and applies the function `f` to each batch.
     The results (each a list) are then flattened into a single list.
@@ -18,7 +22,9 @@ def map_minibatch(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) 
     return list(chain.from_iterable(f(batch) for batch in batches))
 
 
-def map_minibatch_parallel(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) -> List[U]:
+def map_minibatch_parallel(
+    b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]
+) -> List[U]:
     """
     Splits the list `b` into batches of size `batch_size` and applies the function `f` to each batch.
     The results (each a list) are then flattened into a single list.
@@ -28,6 +34,7 @@ def map_minibatch_parallel(b: List[T], batch_size: int, f: Callable[[List[T]], L
     with ThreadPoolExecutor() as executor:
         results = executor.map(f, batches)
     return list(chain.from_iterable(results))
+
 
 def map_unique(b: List[T], f: Callable[[List[T]], List[U]]) -> List[U]:
     """
@@ -42,7 +49,9 @@ def map_unique(b: List[T], f: Callable[[List[T]], List[U]]) -> List[U]:
     return [results[value_to_index[value]] for value in b]
 
 
-def map_unique_minibatch(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) -> List[U]:
+def map_unique_minibatch(
+    b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]
+) -> List[U]:
     """
     Uses minibatch processing on the unique values of the list `b`.
     The function `f` is applied to these unique values in batches,
@@ -51,7 +60,9 @@ def map_unique_minibatch(b: List[T], batch_size: int, f: Callable[[List[T]], Lis
     return map_unique(b, lambda x: map_minibatch(x, batch_size, f))
 
 
-def map_unique_minibatch_parallel(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) -> List[U]:
+def map_unique_minibatch_parallel(
+    b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]
+) -> List[U]:
     """
     Uses minibatch processing on the unique values of the list `b`.
     The function `f` is applied to these unique values in batches using parallel processing,

--- a/openaivec/util.py
+++ b/openaivec/util.py
@@ -11,9 +11,7 @@ def split_to_minibatch(b: List[T], batch_size: int) -> List[List[T]]:
     return [b[i : i + batch_size] for i in range(0, len(b), batch_size)]
 
 
-def map_minibatch(
-    b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]
-) -> List[U]:
+def map_minibatch(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) -> List[U]:
     """
     Splits the list `b` into batches of size `batch_size` and applies the function `f` to each batch.
     The results (each a list) are then flattened into a single list.
@@ -22,9 +20,7 @@ def map_minibatch(
     return list(chain.from_iterable(f(batch) for batch in batches))
 
 
-def map_minibatch_parallel(
-    b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]
-) -> List[U]:
+def map_minibatch_parallel(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) -> List[U]:
     """
     Splits the list `b` into batches of size `batch_size` and applies the function `f` to each batch.
     The results (each a list) are then flattened into a single list.
@@ -49,9 +45,7 @@ def map_unique(b: List[T], f: Callable[[List[T]], List[U]]) -> List[U]:
     return [results[value_to_index[value]] for value in b]
 
 
-def map_unique_minibatch(
-    b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]
-) -> List[U]:
+def map_unique_minibatch(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) -> List[U]:
     """
     Uses minibatch processing on the unique values of the list `b`.
     The function `f` is applied to these unique values in batches,
@@ -60,9 +54,7 @@ def map_unique_minibatch(
     return map_unique(b, lambda x: map_minibatch(x, batch_size, f))
 
 
-def map_unique_minibatch_parallel(
-    b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]
-) -> List[U]:
+def map_unique_minibatch_parallel(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) -> List[U]:
     """
     Uses minibatch processing on the unique values of the list `b`.
     The function `f` is applied to these unique values in batches using parallel processing,

--- a/openaivec/vectorize.py
+++ b/openaivec/vectorize.py
@@ -83,7 +83,11 @@ class VectorizedOpenAI:
     _vectorized_system_message: str = field(init=False)
 
     def __post_init__(self):
-        object.__setattr__(self, "_vectorized_system_message", vectorize_system_message(self.system_message))
+        object.__setattr__(
+            self,
+            "_vectorized_system_message",
+            vectorize_system_message(self.system_message),
+        )
 
     @observe(_logger)
     def request(self, user_messages: List[Message]) -> ParsedChatCompletion[Response]:
@@ -91,17 +95,22 @@ class VectorizedOpenAI:
             model=self.model_name,
             messages=[
                 {"role": "system", "content": self._vectorized_system_message},
-                {"role": "user", "content": Request(user_messages=user_messages).model_dump_json()}
+                {
+                    "role": "user",
+                    "content": Request(user_messages=user_messages).model_dump_json(),
+                },
             ],
             temperature=self.temperature,
             top_p=self.top_p,
-            response_format=Response
+            response_format=Response,
         )
         return completion
 
     @observe(_logger)
     def predict(self, user_messages: List[str]) -> List[str]:
-        messages = [Message(id=i, text=message) for i, message in enumerate(user_messages)]
+        messages = [
+            Message(id=i, text=message) for i, message in enumerate(user_messages)
+        ]
         completion = self.request(messages)
         response_dict = {
             message.id: message.text

--- a/openaivec/vectorize.py
+++ b/openaivec/vectorize.py
@@ -108,13 +108,10 @@ class VectorizedOpenAI:
 
     @observe(_logger)
     def predict(self, user_messages: List[str]) -> List[str]:
-        messages = [
-            Message(id=i, text=message) for i, message in enumerate(user_messages)
-        ]
+        messages = [Message(id=i, text=message) for i, message in enumerate(user_messages)]
         completion = self.request(messages)
         response_dict = {
-            message.id: message.text
-            for message in completion.choices[0].message.parsed.assistant_messages
+            message.id: message.text for message in completion.choices[0].message.parsed.assistant_messages
         }
         sorted_responses = [response_dict.get(m.id, None) for m in messages]
         return sorted_responses

--- a/openaivec/vectorize.py
+++ b/openaivec/vectorize.py
@@ -76,7 +76,7 @@ class Response(BaseModel):
 @dataclass(frozen=True)
 class VectorizedOpenAI:
     client: OpenAI
-    model_name: str  ## it would be the name of deployment for Azure
+    model_name: str  # it would be the name of deployment for Azure
     system_message: str
     temperature: float = 0.0
     top_p: float = 1.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,6 +34,52 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "black"
+version = "25.1.0"
+description = "The uncompromising code formatter."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "black-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32"},
+    {file = "black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da"},
+    {file = "black-25.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7"},
+    {file = "black-25.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9"},
+    {file = "black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0"},
+    {file = "black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299"},
+    {file = "black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096"},
+    {file = "black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2"},
+    {file = "black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b"},
+    {file = "black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc"},
+    {file = "black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f"},
+    {file = "black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba"},
+    {file = "black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f"},
+    {file = "black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3"},
+    {file = "black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171"},
+    {file = "black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18"},
+    {file = "black-25.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0"},
+    {file = "black-25.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"},
+    {file = "black-25.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e"},
+    {file = "black-25.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355"},
+    {file = "black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717"},
+    {file = "black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.10)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -43,6 +89,20 @@ files = [
     {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
     {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
 ]
+
+[[package]]
+name = "click"
+version = "8.1.8"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
+    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
@@ -312,6 +372,17 @@ files = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.2"
 description = "Fundamental package for array computing in Python"
@@ -496,6 +567,33 @@ spss = ["pyreadstat (>=1.2.0)"]
 sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
 test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.6"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "pluggy"
@@ -907,4 +1005,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9956cb0275de724cc9cd66c11f3498bbd544dba9440245486466625109c268a0"
+content-hash = "ce99951074f5bc32b3fb3ec770ba55113a8f892cb6df2125df9fc3a6b889d7df"

--- a/poetry.lock
+++ b/poetry.lock
@@ -81,6 +81,22 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "flake8"
+version = "6.1.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+optional = false
+python-versions = ">=3.8.1"
+files = [
+    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
+    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.11.0,<2.12.0"
+pyflakes = ">=3.1.0,<3.2.0"
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -282,6 +298,17 @@ files = [
     {file = "jiter-0.8.2-cp39-cp39-win32.whl", hash = "sha256:ca29b6371ebc40e496995c94b988a101b9fbbed48a51190a4461fcb0a68b4a36"},
     {file = "jiter-0.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:1c0dfbd1be3cbefc7510102370d86e35d1d53e5a93d48519688b1bf0f761160a"},
     {file = "jiter-0.8.2.tar.gz", hash = "sha256:cd73d3e740666d0e639f678adb176fad25c1bcbdae88d8d7b857e1783bb4212d"},
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 
 [[package]]
@@ -551,6 +578,17 @@ files = [
 test = ["cffi", "hypothesis", "pandas", "pytest", "pytz"]
 
 [[package]]
+name = "pycodestyle"
+version = "2.11.1"
+description = "Python style guide checker"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
+    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.10.6"
 description = "Data validation using Python type hints"
@@ -681,6 +719,17 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
+name = "pyflakes"
+version = "3.1.0"
+description = "passive checker of Python programs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
+    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
+]
 
 [[package]]
 name = "pyspark"
@@ -858,4 +907,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "0619ef3f4615185de5f4af23607dcf1d2eaad45fcc5db57af5557d2bb69f112d"
+content-hash = "9956cb0275de724cc9cd66c11f3498bbd544dba9440245486466625109c268a0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -157,6 +157,25 @@ pycodestyle = ">=2.11.0,<2.12.0"
 pyflakes = ">=3.1.0,<3.2.0"
 
 [[package]]
+name = "flake8-black"
+version = "0.3.6"
+description = "flake8 plugin to call black as a code style validator"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "flake8-black-0.3.6.tar.gz", hash = "sha256:0dfbca3274777792a5bcb2af887a4cad72c72d0e86c94e08e3a3de151bb41c34"},
+    {file = "flake8_black-0.3.6-py3-none-any.whl", hash = "sha256:fe8ea2eca98d8a504f22040d9117347f6b367458366952862ac3586e7d4eeaca"},
+]
+
+[package.dependencies]
+black = ">=22.1.0"
+flake8 = ">=3"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
+
+[package.extras]
+develop = ["build", "twine"]
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -1005,4 +1024,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "ce99951074f5bc32b3fb3ec770ba55113a8f892cb6df2125df9fc3a6b889d7df"
+content-hash = "d3f96835c521851809521a4441214e025661f0c0773281d592e75bfb14b03f1f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,7 @@ version_pattern = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 120
+target-version = ["py310", "py311", "py312", "py313"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ httpx = {extras = ["http2"], version = "^0.28.1"}
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"
 pyarrow = "^19.0.0"
-
+flake8 = "^6.0.0"
 
 [tool.dynamic-versioning]
 enable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pytest = "^8.3.4"
 pyarrow = "^19.0.0"
 flake8 = "^6.0.0"
 black = "^25.1.0"
+flake8-black = "^0.3.6"
 
 [tool.dynamic-versioning]
 enable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ httpx = {extras = ["http2"], version = "^0.28.1"}
 pytest = "^8.3.4"
 pyarrow = "^19.0.0"
 flake8 = "^6.0.0"
+black = "^25.1.0"
 
 [tool.dynamic-versioning]
 enable = true


### PR DESCRIPTION
This pull request introduces a new linting workflow and updates the development dependencies to include `flake8` for code quality checks. The most important changes are as follows:

### Linting Workflow:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R29): Added a new GitHub Actions workflow to run linting on push and pull request events to the `main` branch. This workflow sets up Python 3.10, installs dependencies using Poetry, and runs `flake8` for linting.

### Development Dependencies:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R1-R5): Added configuration for `pre-commit` to use `flake8` for linting.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L24-R24): Added `flake8` as a development dependency.Fixes #21

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/anaregdesign/vectorize-openai/issues/21?shareId=XXXX-XXXX-XXXX-XXXX).