### PR TITLE
Fix/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ steps:
    - Once your environment is set up, go to the **Custom Library** section within that environment.
    - Click on **Add from PyPI** and search for `openaivec` of latest version.
    - Save and publish to reflect the changes.
-   - ![image](https://github.com/user-attachments/assets/57703f15-1a79-4f0f-8f90-7b64ff845e05)
+   - ![image](https://github.com/user-attachments/assets/7b6320db-d9d6-4b89-a49d-e55b1489d1ae)
      *Figure: Add `openaivec` from PyPI to Public Library*
 
 3. **Use the Environment from a Notebook:**
    - Open a notebook within Microsoft Fabric.
    - Select the environment you created in the previous steps.
-   - ![image](https://github.com/user-attachments/assets/7b6320db-d9d6-4b89-a49d-e55b1489d1ae)
+   - ![image](https://github.com/user-attachments/assets/2457c078-1691-461b-b66e-accc3989e419)
      *Figure: Using custom environment from a notebook.*
    - In the notebook, import and use `openaivec.spark.UDFBuilder` as you normally would. For example:
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ steps:
 3. **Use the Environment from a Notebook:**
    - Open a notebook within Microsoft Fabric.
    - Select the environment you created in the previous steps.
-   - ![image](https://github.com/user-attachments/assets/36bc2e26-87c8-4d80-bfc5-bca19300751f)
+   - ![image](https://github.com/user-attachments/assets/7b6320db-d9d6-4b89-a49d-e55b1489d1ae)
      *Figure: Using custom environment from a notebook.*
    - In the notebook, import and use `openaivec.spark.UDFBuilder` as you normally would. For example:
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Example Output:
 | 4127044426148 | Fruit Mix Tea (Trial Size)           | Fruit     | Tea         |
 | ...           | ...                                  | ...       | ...         |
 
+
 ## Using with Microsoft Fabric
 
 [Microsoft Fabric](https://www.microsoft.com/en-us/microsoft-fabric/) is a unified, cloud-based analytics platform that
@@ -147,43 +148,37 @@ actionable insights.
 This section provides instructions on how to integrate and use `vectorize-openai` within Microsoft Fabric. Follow these
 steps:
 
-1. **Download the WHL File:**
-    - Visit the [release page](https://github.com/anaregdesign/vectorize-openai/releases)
-    - Download the latest `openaivec-*.*.*-*.whl` file.
+1. **Create an Environment in Microsoft Fabric:**
+   - In Microsoft Fabric, click on **New item** on your own workspace.
+   - Select **Environment** to create a new environment for Apache Spark.
+   - Determine the environment name, eg. `openai-environment`.
+   - ![image](https://github.com/user-attachments/assets/bd1754ef-2f58-46b4-83ed-b335b64aaa1c)
+     *Figure: Creating a new Environment in Microsoft Fabric.*
 
-2. **Create an Environment in Microsoft Fabric:**
-    - In Microsoft Fabric, click on **New item** on your own workspace.
-    - Select **Environment** to create a new environment for Apache Spark.
-    - Determine the environment name, eg. `openai-environment`.
-    - ![image](https://github.com/user-attachments/assets/bd1754ef-2f58-46b4-83ed-b335b64aaa1c)
-      *Figure: Creating a new Environment in Microsoft Fabric.*
+2. **Add `openaivec` to the Environment from Public Library**
+   - Once your environment is set up, go to the **Custom Library** section within that environment.
+   - Click on **Add from PyPI** and search for `openaivec` of latest version.
+   - Save and publish to reflect the changes.
+   - ![image](https://github.com/user-attachments/assets/57703f15-1a79-4f0f-8f90-7b64ff845e05)
+     *Figure: Add `openaivec` from PyPI to Public Library*
 
-3. **Upload the WHL File via Custom Library:**
-    - Once your environment is set up, go to the **Custom Library** section within that environment.
-    - Click on **Upload** and select the downloaded `.whl` file.
-    - Save and publish to reflect the changes.
-    - ![image](https://github.com/user-attachments/assets/57703f15-1a79-4f0f-8f90-7b64ff845e05)
-      *Figure: Uploading the WHL file to the Custom Library.*
+3. **Use the Environment from a Notebook:**
+   - Open a notebook within Microsoft Fabric.
+   - Select the environment you created in the previous steps.
+   - ![image](https://github.com/user-attachments/assets/36bc2e26-87c8-4d80-bfc5-bca19300751f)
+     *Figure: Using custom environment from a notebook.*
+   - In the notebook, import and use `openaivec.spark.UDFBuilder` as you normally would. For example:
 
-4. **Use the Environment from a Notebook:**
-    - Open a notebook within Microsoft Fabric.
-    - Select the environment you created in the previous steps.
-    - ![image](https://github.com/user-attachments/assets/36bc2e26-87c8-4d80-bfc5-bca19300751f)
-      *Figure: Using custom environment from a notebook.*
-    - In the notebook, import and use `openaivec.spark.UDFBuilder` as you normally would. For example:
+     ```python
+     from openaivec.spark import UDFBuilder
 
-      ```python
-      from openaivec.spark import UDFBuilder
-
-      udf = UDFBuilder(
-          api_key="<your-api-key>",
-          api_version="2024-10-21",
-          endpoint="https://<your-resource-name>.openai.azure.com",
-          model_name="<your-deployment-name"
-      )
-      ```
-
-
+     udf = UDFBuilder(
+         api_key="<your-api-key>",
+         api_version="2024-10-21",
+         endpoint="https://<your-resource-name>.openai.azure.com",
+         model_name="<your-deployment-name"
+     )
+     ```
 
 Following these steps allows you to successfully integrate and use `vectorize-openai` within Microsoft Fabric.
 


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to improve the integration instructions for using `vectorize-openai` with Microsoft Fabric. The most important changes include the removal of the WHL file download step and the addition of instructions to add `openaivec` from the PyPI public library.

Updates to Microsoft Fabric integration instructions:

* Removed the step to download the WHL file and updated the instructions to add `openaivec` from the PyPI public library instead.
* Added a new figure to illustrate adding `openaivec` from PyPI to the public library.

Minor formatting changes:

* Added a blank line before the section header for "Using with Microsoft Fabric" to improve readability.
* Removed unnecessary blank lines for cleaner formatting.