### PR TITLE
improve advices

### DIFF
--- a/openaivec/prompt.py
+++ b/openaivec/prompt.py
@@ -64,7 +64,7 @@ enhance_prompt: str = """
             After these steps, delete any items from the "advices" that are no longer necessary.
             The final output must not contain any unaddressed contradictions or ambiguities.
             Ensure that "purpose," "cautions," and "examples" remain consistent in the final output.
-            If new contradictions or ambiguities arise during the refining process,
+            If new contradictions, ambiguities or any ideas for improvement arise during the refining process,
             add the issues and their possible alternatives to the "advices" field.
         </Instruction>
     </Instructions>
@@ -97,200 +97,14 @@ enhance_prompt: str = """
                             "source": "<source5>",
                             "result": "<result5>"
                         }
-                    ]
-                }
-            </Input>
-            <Output>
-                {
-                    "purpose": "<some_purpose>",
-                    "cautions": ["<caution1>", "<caution2>"],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
-                        }
-                    ]
-                }
-            </Output>
-        </Example>
-
-        <!-- with improved purpose -->
-        <Example>
-            <Input>
-                {
-                    "purpose": "<some_purpose>",
-                    "cautions": ["<caution1>", "<caution2>"],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
-                        }
-                    ]
+                    ],
+                    "advices": ["<advice1>", "<advice2>"]
                 }
             </Input>
             <Output>
                 {
                     "purpose": "<improved_purpose>",
-                    "cautions": ["<caution1>", "<caution2>"],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
-                        }
-                    ]
-                }
-            </Output>
-        </Example>
-
-        <!-- with additional cautions -->
-        <Example>
-            <Input>
-                {
-                    "purpose": "<some_purpose>",
-                    "cautions": ["<caution1>", "<caution2>"],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
-                        }
-                    ]
-                }
-            </Input>
-            <Output>
-                {
-                    "purpose": "<improved_purpose>",
-                    "cautions": [
-                        "<caution1>",
-                        "<caution2>",
-                        "<additional_caution1>",
-                        "<additional_caution2>"
-                    ],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
-                        }
-                    ]
-                }
-            </Output>
-        </Example>
-
-        <!-- with additional examples -->
-        <Example>
-            <Input>
-                {
-                    "purpose": "<some_purpose>",
-                    "cautions": ["<caution1>"],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
-                        }
-                    ]
-                }
-            </Input>
-            <Output>
-                {
-                    "purpose": "<improved_purpose>",
-                    "cautions": [
-                        "<caution1>"
-                    ],
+                    "cautions": ["<caution1>", "<new_caution1>"],
                     "examples": [
                         {
                             "source": "<source1>",
@@ -313,152 +127,15 @@ enhance_prompt: str = """
                             "result": "<result5>"
                         },
                         {
-                            "source": "<additional_source1>",
-                            "result": "<additional_result1>"
+                            "source": "<new_source1>",
+                            "result": "<new_result1>"
                         },
                         {
-                            "source": "<additional_source2>",
-                            "result": "<additional_result2>"
-                        }
-                    ]
-                }
-            </Output>
-        </Example>
-
-        <!-- with additional examples and cautions -->
-        <Example>
-            <Input>
-                {
-                    "purpose": "<some_purpose>",
-                    "cautions": [],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
-                        }
-                    ]
-                }
-            </Input>
-            <Output>
-                {
-                    "purpose": "<improved_purpose>",
-                    "cautions": [
-                        "<additional_caution1>",
-                        "<additional_caution2>"
-                    ],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
-                        },
-                        {
-                            "source": "<additional_source1>",
-                            "result": "<additional_result1>"
-                        },
-                        {
-                            "source": "<additional_source2>",
-                            "result": "<additional_result2>"
-                        }
-                    ]
-                }
-            </Output>
-        </Example>
-
-        <!-- with advices -->
-        <Example>
-            <Input>
-                {
-                    "purpose": "<some_purpose>",
-                    "cautions": ["<caution1>"],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
+                            "source": "<new_source2>",
+                            "result": "<new_result2>"
                         }
                     ],
-                    "advices": ["<advice1>"]
-                }
-            </Input>
-            <Output>
-                {
-                    "purpose": "<improved_purpose>",
-                    "cautions": [
-                        "<caution1>"
-                    ],
-                    "examples": [
-                        {
-                            "source": "<source1>",
-                            "result": "<result1>"
-                        },
-                        {
-                            "source": "<source2>",
-                            "result": "<result2>"
-                        },
-                        {
-                            "source": "<source3>",
-                            "result": "<result3>"
-                        },
-                        {
-                            "source": "<source4>",
-                            "result": "<result4>"
-                        },
-                        {
-                            "source": "<source5>",
-                            "result": "<result5>"
-                        }
-                    ],
-                    "advices": [
-                        "<advice1>",
-                        "<advice2>"
-                    ]
+                    "advices": ["<new_advice1>", "<new_advice2>"]
                 }
             </Output>
         </Example>

--- a/openaivec/prompt.py
+++ b/openaivec/prompt.py
@@ -59,13 +59,11 @@ enhance_prompt: str = """
             - If "advices" is present, use them to refine or adjust existing "examples" ensuring consistency throughout.
         </Instruction>
 
-        <!-- Step 5: Resolve contradictions or ambiguities -->
+        <!-- Step 5: Resolve contradictions, ambiguities or redundancies -->
         <Instruction>
-            After these steps, delete any items from the "advices" that are no longer necessary.
-            The final output must not contain any unaddressed contradictions or ambiguities.
             Ensure that "purpose," "cautions," and "examples" remain consistent in the final output.
-            If new contradictions, ambiguities or any ideas for improvement arise during the refining process,
-            add the issues and their possible alternatives to the "advices" field.
+            If some contradictions, ambiguities or redundancies are found,
+            add solutions that are as detailed and specific as possible to the "advices" field.
         </Instruction>
     </Instructions>
 
@@ -206,7 +204,6 @@ class FewShotPromptBuilder:
             response_format=FewShotPrompt,
         )
         self._prompt = completion.choices[0].message.parsed
-        self._warn_advices()
         return self
 
     def improve(self, client: OpenAI, model_name: str, max_iter: int = 5) -> "FewShotPromptBuilder":
@@ -214,6 +211,7 @@ class FewShotPromptBuilder:
             _logger.info("Iteration %d", i + 1)
             original: str = self.build()
             self.enhance(client, model_name)
+            self._warn_advices()
             improved: str = self.build()
 
             if original == improved:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1038,4 +1038,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d133a572146ddef6c24276841c9dc9bbb9fe80b414ced969ecb170163ce4e818"
+content-hash = "e9cfefe2acae476cb159f913c577d1ff48f54abca1aa757e505ce5e38a3b6f55"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ pandas = "^2.2.3"
 pyspark = "^3.5.1"
 openai = "^1.57.2"
 httpx = {extras = ["http2"], version = "^0.28.1"}
-langdetect = "^1.0.9"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"
@@ -25,6 +24,7 @@ pyarrow = "^19.0.0"
 flake8 = "^6.0.0"
 black = "^25.1.0"
 flake8-black = "^0.3.6"
+langdetect = "^1.0.9"
 
 [tool.dynamic-versioning]
 enable = true


### PR DESCRIPTION
This pull request includes several changes to the `openaivec/prompt.py` file to refine instructions and examples, and a minor update to the `pyproject.toml` file. The most important changes include refining the instructions to resolve contradictions, removing redundant examples, and adjusting the order of dependencies in the `pyproject.toml` file.

Changes to `openaivec/prompt.py`:

* Refined instructions to resolve contradictions, ambiguities, or redundancies, and updated the handling of "advices" to include detailed and specific solutions.
* Removed redundant examples from the prompt, simplifying the structure and focusing on a single improved example format. [[1]](diffhunk://#diff-31b45a7e298fcc9eafff87b7c4782886baece54d9372431696b374b092e9fcebL100-R105) [[2]](diffhunk://#diff-31b45a7e298fcc9eafff87b7c4782886baece54d9372431696b374b092e9fcebL425-R136)
* Moved the `_warn_advices` method call to the `improve` method after enhancing the prompt.

Changes to `pyproject.toml`:

* Adjusted the order of the `langdetect` dependency to be grouped with other dependencies.