### PR TITLE
Feature/sparkjson

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
+# What is this?
+We can do like this:
+
+```python
+class Fruit(pydantic.BaseModel):
+   name: str
+   color: str
+   taste: str
+
+prompt = """
+    return the color and taste of given fruit.
+
+    #example
+
+    ## input
+    apple
+
+    ## output
+    {{
+        "name": "apple",
+        "color": "red",
+        "taste": "sweet"
+    }}
+"""
+# Simple UDF builder in openaivec
+udf = UDFBuilder(...)
+
+# Register UDFs with structured output
+spark.udf.register("parse_fruit", udf.completion(prompt, respose_format=Fruit))
+
+# Use UDFs in Spark SQL
+spark.sql("SELECT name, parse_fruit(name) from dummy").show(truncate=False)
+```
+
+Then we will get the output like this:
+```text
++------+--------------------------------------------------------+
+|name  |fruit(name)                                             |
++------+--------------------------------------------------------+
+|apple |{"name":"apple","color":"red","taste":"sweet"}          |
+|banana|{"name":"banana","color":"yellow","taste":"sweet"}      |
+|cherry|{"name":"cherry","color":"red","taste":"sweet and tart"}|
++------+--------------------------------------------------------+
+```
+
+
+
 # Overview
 
 This package provides a vectorized interface for the OpenAI API, enabling you to process multiple inputs with a single

--- a/openaivec/test_spark.py
+++ b/openaivec/test_spark.py
@@ -84,6 +84,6 @@ class TestUDFBuilder(TestCase):
 
         self.spark.sql(
             """
-            SELECT id, fruit(name) as v from dummy
+            SELECT fruit(name) as v from dummy
             """
         ).show(truncate=False)

--- a/openaivec/test_spark.py
+++ b/openaivec/test_spark.py
@@ -84,6 +84,6 @@ class TestUDFBuilder(TestCase):
 
         self.spark.sql(
             """
-            SELECT fruit(name) as v from dummy
+            SELECT name, fruit(name) from dummy
             """
         ).show(truncate=False)

--- a/openaivec/test_util.py
+++ b/openaivec/test_util.py
@@ -1,5 +1,7 @@
-from typing import List
+from typing import List, Type
 from unittest import TestCase
+
+from openai import BaseModel
 
 from openaivec.util import (
     split_to_minibatch,
@@ -8,6 +10,8 @@ from openaivec.util import (
     map_unique_minibatch,
     map_unique_minibatch_parallel,
     map_minibatch_parallel,
+    serialize_base_model,
+    deserialize_base_model,
 )
 
 
@@ -105,3 +109,14 @@ class TestMappingFunctions(TestCase):
         # Mapping back for original list: [9, 4, 9, 1]
         expected = [9, 4, 9, 1]
         self.assertEqual(map_unique_minibatch_parallel(b, batch_size, square_list), expected)
+
+    def test_serialize_and_deserialize(self):
+        class IntValue(BaseModel):
+            value: int
+
+        source = serialize_base_model(IntValue)
+        cls: Type[BaseModel] = deserialize_base_model(source, "IntValue")
+
+        six = cls(value=6)
+
+        self.assertEqual(six.value, 6)

--- a/openaivec/util.py
+++ b/openaivec/util.py
@@ -79,4 +79,7 @@ def deserialize_base_model(source: str, class_name: str) -> Type[BaseModel]:
     dedented_source = textwrap.dedent(source)
     exec(dedented_source, namespace)
 
+    if not issubclass(namespace[class_name], BaseModel):
+        raise ValueError(f"{class_name} is not a subclass of pydantic.BaseModel")
+
     return namespace[class_name]

--- a/openaivec/util.py
+++ b/openaivec/util.py
@@ -1,6 +1,10 @@
+import inspect
+import textwrap
 from concurrent.futures.thread import ThreadPoolExecutor
 from itertools import chain
-from typing import List, TypeVar, Callable
+from typing import List, TypeVar, Callable, Type
+
+from pydantic import BaseModel
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -61,3 +65,18 @@ def map_unique_minibatch_parallel(b: List[T], batch_size: int, f: Callable[[List
     and the results are mapped back to match the order of the original list.
     """
     return map_unique(b, lambda x: map_minibatch_parallel(x, batch_size, f))
+
+
+def serialize_base_model(obj: Type[BaseModel]) -> str:
+    if not isinstance(obj, type) or not issubclass(obj, BaseModel):
+        raise ValueError("obj must be a subclass of pydantic.BaseModel")
+
+    return inspect.getsource(obj)
+
+
+def deserialize_base_model(source: str, class_name: str) -> Type[BaseModel]:
+    namespace = {"BaseModel": BaseModel}
+    dedented_source = textwrap.dedent(source)
+    exec(dedented_source, namespace)
+
+    return namespace[class_name]


### PR DESCRIPTION
This pull request introduces several enhancements to the `openaivec` package, focusing on integrating structured output using Pydantic models and improving the utility functions. The most important changes include adding a new example to the `README.md`, modifying the `UDFBuilder` to support structured output, and updating the test cases to validate these new features.

Enhancements to documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R47): Added an example demonstrating how to use the `UDFBuilder` with structured output using Pydantic models.

Enhancements to `UDFBuilder`:

* [`openaivec/spark.py`](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aL4-R15): Modified the `UDFBuilder` to support structured output by accepting a Pydantic model as the `response_format` parameter. This includes changes to the `completion` method and the `get_vectorized_openai_client` function. [[1]](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aL4-R15) [[2]](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aR28-R30) [[3]](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aL44-R51) [[4]](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aR60) [[5]](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aL103-R153)

Enhancements to utility functions:

* [`openaivec/util.py`](diffhunk://#diff-179da1f7a5daf31a82dcbfbc65f4dd1c3b0ec826360ccea75e0794a38ab77176R1-R7): Added `serialize_base_model` and `deserialize_base_model` functions to serialize and deserialize Pydantic models. [[1]](diffhunk://#diff-179da1f7a5daf31a82dcbfbc65f4dd1c3b0ec826360ccea75e0794a38ab77176R1-R7) [[2]](diffhunk://#diff-179da1f7a5daf31a82dcbfbc65f4dd1c3b0ec826360ccea75e0794a38ab77176R68-R85)

Updates to test cases:

* [`openaivec/test_spark.py`](diffhunk://#diff-00245e7727fcd1da9a4b8b055dbd456eaf1759c29061b9f3487d836c331a8debR4): Added a new test case `test_completion_structured` to validate the structured output functionality using a Pydantic model. [[1]](diffhunk://#diff-00245e7727fcd1da9a4b8b055dbd456eaf1759c29061b9f3487d836c331a8debR4) [[2]](diffhunk://#diff-00245e7727fcd1da9a4b8b055dbd456eaf1759c29061b9f3487d836c331a8debR54-R89)
* [`openaivec/test_util.py`](diffhunk://#diff-486a0e52c698b366096d1fc64ed249121ec74a407daa7158bcb2028809462da7L1-R14): Added a new test case `test_serialize_and_deserialize` to validate the serialization and deserialization of Pydantic models. [[1]](diffhunk://#diff-486a0e52c698b366096d1fc64ed249121ec74a407daa7158bcb2028809462da7L1-R14) [[2]](diffhunk://#diff-486a0e52c698b366096d1fc64ed249121ec74a407daa7158bcb2028809462da7R112-R122)