### PR TITLE
fix: bug fix about parallelism

### DIFF
--- a/openaivec/spark.py
+++ b/openaivec/spark.py
@@ -160,9 +160,9 @@ class UDFBuilder:
 
             for part in col:
                 if self.is_parallel:
-                    predictions = client_vec.predict_minibatch(part.tolist(), self.batch_size)
+                    predictions = client_vec.predict_minibatch_parallel(part.tolist(), self.batch_size)
                 else:
-                    predictions = client_vec.predict(part.tolist())
+                    predictions = client_vec.predict_minibatch(part.tolist(), self.batch_size)
                 result = pd.Series(predictions)
                 yield pd.DataFrame(result.map(_safe_dump).tolist())
 
@@ -178,9 +178,9 @@ class UDFBuilder:
 
             for part in col:
                 if self.is_parallel:
-                    predictions = client_vec.predict_minibatch(part.tolist(), self.batch_size)
+                    predictions = client_vec.predict_minibatch_parallel(part.tolist(), self.batch_size)
                 else:
-                    predictions = client_vec.predict(part.tolist())
+                    predictions = client_vec.predict_minibatch(part.tolist(), self.batch_size)
                 result = pd.Series(predictions)
                 yield result.map(_safe_cast_str)
 

--- a/openaivec/vectorize.py
+++ b/openaivec/vectorize.py
@@ -8,7 +8,7 @@ from openai.types.chat import ParsedChatCompletion
 from pydantic import BaseModel
 
 from openaivec.log import observe
-from openaivec.util import map_unique_minibatch_parallel
+from openaivec.util import map_unique_minibatch_parallel, map_unique_minibatch
 
 __ALL__ = ["VectorizedLLM", "GeneralVectorizedOpenAI", "VectorizedOpenAI"]
 
@@ -89,6 +89,10 @@ class VectorizedLLM(Generic[T], metaclass=ABCMeta):
     def predict_minibatch(self, user_messages: List[str], batch_size: int) -> List[T]:
         pass
 
+    @abstractmethod
+    def predict_minibatch_parallel(self, user_messages: List[str], batch_size: int) -> List[T]:
+        pass
+
 
 @dataclass(frozen=True)
 class VectorizedOpenAI(VectorizedLLM, Generic[T]):
@@ -146,4 +150,8 @@ class VectorizedOpenAI(VectorizedLLM, Generic[T]):
 
     @observe(_logger)
     def predict_minibatch(self, user_messages: List[str], batch_size: int) -> List[T]:
+        return map_unique_minibatch(user_messages, batch_size, self.predict)
+
+    @observe(_logger)
+    def predict_minibatch_parallel(self, user_messages: List[str], batch_size: int) -> List[T]:
         return map_unique_minibatch_parallel(user_messages, batch_size, self.predict)


### PR DESCRIPTION
This pull request includes changes to enhance the parallel processing capabilities of the `openaivec` package by introducing a new method for parallel minibatch predictions and updating existing functions to utilize this new method.

Enhancements to parallel processing:

* [`openaivec/spark.py`](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aL163-R165): Updated the `fn_struct` and `fn_str` functions to use the new `predict_minibatch_parallel` method for parallel processing. [[1]](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aL163-R165) [[2]](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aL181-R183)

New method for parallel minibatch predictions:

* [`openaivec/vectorize.py`](diffhunk://#diff-8976a93d17a2a5e0a1e0886cb7d519e1fc7b8648ab83c0b6b051774946e177dbR92-R95): Added the `predict_minibatch_parallel` method to the abstract base class and implemented it in the `VectorizedOpenAI` class. This method uses `map_unique_minibatch_parallel` for processing. [[1]](diffhunk://#diff-8976a93d17a2a5e0a1e0886cb7d519e1fc7b8648ab83c0b6b051774946e177dbR92-R95) [[2]](diffhunk://#diff-8976a93d17a2a5e0a1e0886cb7d519e1fc7b8648ab83c0b6b051774946e177dbR153-R156)

Import updates:

* [`openaivec/vectorize.py`](diffhunk://#diff-8976a93d17a2a5e0a1e0886cb7d519e1fc7b8648ab83c0b6b051774946e177dbL11-R11): Updated imports to include the new `map_unique_minibatch` function.