### PR TITLE
Refactor/ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-ignore = E501, W503, E203
-per-file-ignores =
-    __init__.py: F401

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,5 +25,5 @@ jobs:
           echo "${HOME}/.local/bin" >> $GITHUB_PATH
           poetry install --with dev --no-interaction --no-ansi
 
-      - name: Run flake8
-        run: poetry run flake8
+      - name: Run ruff
+        run: poetry run ruff check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,0 @@
-repos:
-  - repo: https://github.com/pre-commit/mirrors-flake8
-    rev: v3.9.2
-    hooks:
-      - id: flake8

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.linting.enabled": true,
+    "python.linting.ruffEnabled": true,
+    "python.linting.flake8Enabled": false,
+    "python.formatting.provider": "ruff",
+    "editor.formatOnSave": true
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,22 +19,10 @@ To install the necessary dependencies for development, run:
 poetry install --dev
 ```
 
-## Running black
+## Running ruff
 
 To reformat the code, use the following command:
 
 ```bash
-poetry run black ./openaivec
-```
-
-## Linting Guidance
-
-To maintain code quality and consistency, we use `flake8` for linting. Please ensure your code passes the linting checks before submitting a pull request.
-
-### Running flake8
-
-To run `flake8` and check for linting issues, use the following command:
-
-```bash
-poetry run flake8 ./openaivec
+poetry run ruff check . --fix
 ```

--- a/README.md
+++ b/README.md
@@ -401,15 +401,7 @@ poetry install --dev
 To reformat the code, use the following command:
 
 ```bash
-poetry run black ./openaivec
-```
-
-### Linting
-
-To check for linting issues, use the following command:
-
-```bash
-poetry run flake8 ./openaivec
+poetry run ruff check . --fix
 ```
 
 ## Community

--- a/openaivec/__init__.py
+++ b/openaivec/__init__.py
@@ -1,7 +1,7 @@
 from .embedding import EmbeddingOpenAI
 from .vectorize import VectorizedOpenAI
 
-__ALL__ = [
+__all__ = [
     "VectorizedOpenAI",
     "EmbeddingOpenAI",
 ]

--- a/openaivec/embedding.py
+++ b/openaivec/embedding.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from logging import getLogger, Logger
+from logging import Logger, getLogger
 from typing import List
 
 import numpy as np

--- a/openaivec/log.py
+++ b/openaivec/log.py
@@ -12,9 +12,9 @@ def observe(logger: Logger):
     def decorator(func: Callable) -> Callable:
         @functools.wraps(func)
         def decorated(self: object, *args, **kwargs):
-            l: Logger = logger.getChild(self.__class__.__name__).getChild(func.__name__)
+            child_logger: Logger = logger.getChild(self.__class__.__name__).getChild(func.__name__)
             transaction_id: str = str(uuid.uuid4())
-            l.info(
+            child_logger.info(
                 json.dumps(
                     {
                         "transaction_id": transaction_id,
@@ -29,7 +29,7 @@ def observe(logger: Logger):
                 res = func(self, *args, **kwargs)
 
             finally:
-                l.info(
+                child_logger.info(
                     json.dumps(
                         {
                             "transaction_id": transaction_id,

--- a/openaivec/serialize.py
+++ b/openaivec/serialize.py
@@ -1,8 +1,7 @@
 from enum import Enum
-from typing import Type, Any, Dict, List
+from typing import Any, Dict, List, Type
 
 from pydantic import BaseModel, create_model
-
 
 __ALL__ = ["deserialize_base_model", "serialize_base_model"]
 

--- a/openaivec/spark.py
+++ b/openaivec/spark.py
@@ -1,18 +1,18 @@
 from dataclasses import dataclass
-from logging import getLogger, Logger
-from typing import Iterator, Optional, TypeVar, Type
+from logging import Logger, getLogger
+from typing import Iterator, Optional, Type, TypeVar
 
 import httpx
 import pandas as pd
 import tiktoken
-from openai import OpenAI, AzureOpenAI
+from openai import AzureOpenAI, OpenAI
 from pydantic import BaseModel
 from pyspark.sql.pandas.functions import pandas_udf
-from pyspark.sql.types import StringType, ArrayType, FloatType, IntegerType
+from pyspark.sql.types import ArrayType, FloatType, IntegerType, StringType
 
-from openaivec import VectorizedOpenAI, EmbeddingOpenAI
+from openaivec import EmbeddingOpenAI, VectorizedOpenAI
 from openaivec.log import observe
-from openaivec.serialize import serialize_base_model, deserialize_base_model
+from openaivec.serialize import deserialize_base_model, serialize_base_model
 from openaivec.util import pydantic_to_spark_schema
 from openaivec.vectorize import VectorizedLLM
 

--- a/openaivec/util.py
+++ b/openaivec/util.py
@@ -1,10 +1,9 @@
 from concurrent.futures.thread import ThreadPoolExecutor
 from itertools import chain
-from typing import TypeVar, Callable, Type
-from typing import get_origin, get_args, List, Union
+from typing import Callable, List, Type, TypeVar, Union, get_args, get_origin
 
 from pydantic import BaseModel
-from pyspark.sql.types import StructType, StructField, IntegerType, FloatType, StringType, BooleanType, ArrayType
+from pyspark.sql.types import ArrayType, BooleanType, FloatType, IntegerType, StringType, StructField, StructType
 
 T = TypeVar("T")
 U = TypeVar("U")

--- a/openaivec/util.py
+++ b/openaivec/util.py
@@ -88,13 +88,13 @@ def python_type_to_spark(python_type):
         return pydantic_to_spark_schema(python_type)
 
     # Basic type mapping
-    elif python_type == int:
+    elif python_type is int:
         return IntegerType()
-    elif python_type == float:
+    elif python_type is float:
         return FloatType()
-    elif python_type == str:
+    elif python_type is str:
         return StringType()
-    elif python_type == bool:
+    elif python_type is bool:
         return BooleanType()
     else:
         raise ValueError(f"Unsupported type: {python_type}")

--- a/openaivec/vectorize.py
+++ b/openaivec/vectorize.py
@@ -1,14 +1,14 @@
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from logging import Logger, getLogger
-from typing import List, TypeVar, Generic, Type, cast
+from typing import Generic, List, Type, TypeVar, cast
 
 from openai import OpenAI
 from openai.types.chat import ParsedChatCompletion
 from pydantic import BaseModel
 
 from openaivec.log import observe
-from openaivec.util import map_unique_minibatch_parallel, map_unique_minibatch
+from openaivec.util import map_unique_minibatch, map_unique_minibatch_parallel
 
 __ALL__ = ["VectorizedLLM", "GeneralVectorizedOpenAI", "VectorizedOpenAI"]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -60,52 +60,6 @@ astroid = ["astroid (>=2,<4)"]
 test = ["astroid (>=2,<4)", "pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-name = "black"
-version = "25.1.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "black-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32"},
-    {file = "black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da"},
-    {file = "black-25.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7"},
-    {file = "black-25.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9"},
-    {file = "black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0"},
-    {file = "black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299"},
-    {file = "black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096"},
-    {file = "black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2"},
-    {file = "black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b"},
-    {file = "black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc"},
-    {file = "black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f"},
-    {file = "black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba"},
-    {file = "black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f"},
-    {file = "black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3"},
-    {file = "black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171"},
-    {file = "black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18"},
-    {file = "black-25.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0"},
-    {file = "black-25.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"},
-    {file = "black-25.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e"},
-    {file = "black-25.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355"},
-    {file = "black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717"},
-    {file = "black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "certifi"
 version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -297,20 +251,6 @@ files = [
 ]
 
 [[package]]
-name = "click"
-version = "8.1.8"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
-    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -422,41 +362,6 @@ files = [
 
 [package.extras]
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich"]
-
-[[package]]
-name = "flake8"
-version = "6.1.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-files = [
-    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
-    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.11.0,<2.12.0"
-pyflakes = ">=3.1.0,<3.2.0"
-
-[[package]]
-name = "flake8-black"
-version = "0.3.6"
-description = "flake8 plugin to call black as a code style validator"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-black-0.3.6.tar.gz", hash = "sha256:0dfbca3274777792a5bcb2af887a4cad72c72d0e86c94e08e3a3de151bb41c34"},
-    {file = "flake8_black-0.3.6-py3-none-any.whl", hash = "sha256:fe8ea2eca98d8a504f22040d9117347f6b367458366952862ac3586e7d4eeaca"},
-]
-
-[package.dependencies]
-black = ">=22.1.0"
-flake8 = ">=3"
-tomli = {version = "*", markers = "python_version < \"3.11\""}
-
-[package.extras]
-develop = ["build", "twine"]
 
 [[package]]
 name = "h11"
@@ -823,28 +728,6 @@ files = [
 traitlets = "*"
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 description = "Patch asyncio to allow nested event loops"
@@ -1057,17 +940,6 @@ qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
 testing = ["docopt", "pytest"]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
 name = "pexpect"
 version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -1240,17 +1112,6 @@ files = [
 test = ["cffi", "hypothesis", "pandas", "pytest", "pytz"]
 
 [[package]]
-name = "pycodestyle"
-version = "2.11.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
-    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -1392,17 +1253,6 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
-
-[[package]]
-name = "pyflakes"
-version = "3.1.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
-    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
-]
 
 [[package]]
 name = "pygments"
@@ -1769,6 +1619,33 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "ruff"
+version = "0.11.0"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.11.0-py3-none-linux_armv6l.whl", hash = "sha256:dc67e32bc3b29557513eb7eeabb23efdb25753684b913bebb8a0c62495095acb"},
+    {file = "ruff-0.11.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38c23fd9bdec4eb437b4c1e3595905a0a8edfccd63a790f818b28c78fe345639"},
+    {file = "ruff-0.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c8661b0be91a38bd56db593e9331beaf9064a79028adee2d5f392674bbc5e88"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6c0e8d3d2db7e9f6efd884f44b8dc542d5b6b590fc4bb334fdbc624d93a29a2"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c3156d3f4b42e57247275a0a7e15a851c165a4fc89c5e8fa30ea6da4f7407b8"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:490b1e147c1260545f6d041c4092483e3f6d8eba81dc2875eaebcf9140b53905"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1bc09a7419e09662983b1312f6fa5dab829d6ab5d11f18c3760be7ca521c9329"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcfa478daf61ac8002214eb2ca5f3e9365048506a9d52b11bea3ecea822bb844"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6fbb2aed66fe742a6a3a0075ed467a459b7cedc5ae01008340075909d819df1e"},
+    {file = "ruff-0.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c0c1ff014351c0b0cdfdb1e35fa83b780f1e065667167bb9502d47ca41e6db"},
+    {file = "ruff-0.11.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e4fd5ff5de5f83e0458a138e8a869c7c5e907541aec32b707f57cf9a5e124445"},
+    {file = "ruff-0.11.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:96bc89a5c5fd21a04939773f9e0e276308be0935de06845110f43fd5c2e4ead7"},
+    {file = "ruff-0.11.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a9352b9d767889ec5df1483f94870564e8102d4d7e99da52ebf564b882cdc2c7"},
+    {file = "ruff-0.11.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:049a191969a10897fe052ef9cc7491b3ef6de79acd7790af7d7897b7a9bfbcb6"},
+    {file = "ruff-0.11.0-py3-none-win32.whl", hash = "sha256:3191e9116b6b5bbe187447656f0c8526f0d36b6fd89ad78ccaad6bdc2fad7df2"},
+    {file = "ruff-0.11.0-py3-none-win_amd64.whl", hash = "sha256:c58bfa00e740ca0a6c43d41fb004cd22d165302f360aaa56f7126d544db31a21"},
+    {file = "ruff-0.11.0-py3-none-win_arm64.whl", hash = "sha256:868364fc23f5aa122b00c6f794211e85f7e78f5dffdf7c590ab90b8c4e69b657"},
+    {file = "ruff-0.11.0.tar.gz", hash = "sha256:e55c620690a4a7ee6f1cccb256ec2157dc597d109400ae75bbf944fc9d6462e2"},
+]
+
+[[package]]
 name = "setuptools"
 version = "76.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -2026,4 +1903,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "0ba5293287acf6f5889fe3beaafa51bcbd1ece06f385bb473caeb230c9fd8a6b"
+content-hash = "45a1c4922f0e5038d91c1e9d283fb909ed04850509efa383e5511362d9937a0f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1903,4 +1903,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "45a1c4922f0e5038d91c1e9d283fb909ed04850509efa383e5511362d9937a0f"
+content-hash = "1e3e4272e84a840c8de856233fbce3441060dd9af826a8bfc2a04e76bd99cd01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,9 @@ ipykernel = "^6.29.5"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"
 pyarrow = "^19.0.0"
-flake8 = "^6.0.0"
-black = "^25.1.0"
-flake8-black = "^0.3.6"
 langdetect = "^1.0.9"
 pytest-dotenv = "^0.5.2"
+ruff = "^0.11.0"
 
 [tool.dynamic-versioning]
 enable = true
@@ -37,10 +35,6 @@ version_pattern = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.black]
-line-length = 120
-target-version = ["py310", "py311", "py312", "py313"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ openai = "^1.66.3"
 httpx = {extras = ["http2"], version = "^0.28.1"}
 tiktoken = "^0.9.0"
 setuptools = "^76.0.0"
-ipykernel = "^6.29.5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"
@@ -27,6 +26,7 @@ pyarrow = "^19.0.0"
 langdetect = "^1.0.9"
 pytest-dotenv = "^0.5.2"
 ruff = "^0.11.0"
+ipykernel = "^6.29.5"
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,17 @@ langdetect = "^1.0.9"
 pytest-dotenv = "^0.5.2"
 ruff = "^0.11.0"
 
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
 [tool.dynamic-versioning]
 enable = true
 version_pattern = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,16 +2,16 @@ from typing import List
 from unittest import TestCase
 
 from openai import BaseModel
-from pyspark.sql.types import StructField, IntegerType, StringType, ArrayType, FloatType, StructType
+from pyspark.sql.types import ArrayType, FloatType, IntegerType, StringType, StructField, StructType
 
 from openaivec.util import (
-    split_to_minibatch,
     map_minibatch,
+    map_minibatch_parallel,
     map_unique,
     map_unique_minibatch,
     map_unique_minibatch_parallel,
-    map_minibatch_parallel,
     pydantic_to_spark_schema,
+    split_to_minibatch,
 )
 
 

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -1,5 +1,5 @@
 import os
-from logging import basicConfig, Handler, StreamHandler
+from logging import Handler, StreamHandler, basicConfig
 from typing import List
 from unittest import TestCase
 


### PR DESCRIPTION
This pull request includes a significant shift from using `flake8` to `ruff` for linting and formatting, along with various code improvements and updates to configuration files.

### Linting and Formatting Changes:
* [`.flake8`](diffhunk://#diff-6951dbb399883798a226c1fb496fdb4183b1ab48865e75eddecf6ceb6cf46442L1-L4): Removed the `flake8` configuration file.
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L28-R29): Changed the linting command from `flake8` to `ruff`.
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L1-L5): Removed the `flake8` pre-commit hook.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R12): Updated VSCode settings to use `ruff` for linting and formatting.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L22-R40): Replaced `flake8` and `black` with `ruff` and added `ruff` configuration. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L22-R40) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L41-L44)

### Documentation Updates:
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L22-R27): Updated instructions to use `ruff` for code formatting and linting.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L404-R404): Updated the linting command to use `ruff`.

### Code Improvements:
* Various files: Improved import ordering and consistency. [[1]](diffhunk://#diff-6ee771a1866417de265e29de12e978ad24c948b0629959c238f56f9f5720be38L2-R2) [[2]](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aL2-R15) [[3]](diffhunk://#diff-179da1f7a5daf31a82dcbfbc65f4dd1c3b0ec826360ccea75e0794a38ab77176L3-R6) [[4]](diffhunk://#diff-8976a93d17a2a5e0a1e0886cb7d519e1fc7b8648ab83c0b6b051774946e177dbL4-R11) [[5]](diffhunk://#diff-0dcbadaa6c70afb6fea041dec04bb89c3cc7fe201fb7c3185a669efa49769f28L5-R14) [[6]](diffhunk://#diff-49e74d8cc71a7f2aa78565a265c04617b38e732c60beb4e2c490a47f2c9da9d7L2-R2)
* [`openaivec/log.py`](diffhunk://#diff-c21fd4190f3782bb7d474a3ede17fc9fd9fc4a9d27fa66b1a5938f79c60f661bL15-R17): Renamed variables for clarity. [[1]](diffhunk://#diff-c21fd4190f3782bb7d474a3ede17fc9fd9fc4a9d27fa66b1a5938f79c60f661bL15-R17) [[2]](diffhunk://#diff-c21fd4190f3782bb7d474a3ede17fc9fd9fc4a9d27fa66b1a5938f79c60f661bL32-R32)
* [`openaivec/util.py`](diffhunk://#diff-179da1f7a5daf31a82dcbfbc65f4dd1c3b0ec826360ccea75e0794a38ab77176L92-R97): Updated type comparison to use `is` instead of `==`.

### Minor Fixes:
* [`openaivec/__init__.py`](diffhunk://#diff-4849dea0839260af4f013b7e6a1319e5d3c9820ac74062cfd1f3de0f021c4bd9L4-R4): Corrected the case of `__all__`.
* [`openaivec/serialize.py`](diffhunk://#diff-c4925ace5cc15eb42d2dba0212c07e2a0028044de9796a179b5fdfda477bba81L2-L6): Removed an unnecessary blank line.