### PR TITLE
Readme/pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,16 @@ print(result)  # Expected output: ['bear family', 'rabbit family', 'koala family
 See [examples/basic_usage.ipynb](examples/basic_usage.ipynb) for a complete example.
 
 ## Using with Pandas DataFrame
+`openaivec.pandas_ext` extends `pandas.Series` functions with accessor `ai.predict` or `ai.embed`.
 
 ```python
 import pandas as pd
+from openaivec import pandas_ext
 
 df = pd.DataFrame({"name": ["panda", "rabbit", "koala"]})
 
 df.assign(
-    kind=lambda df: client.predict(df.name)
+    kind=lambda df: df.name.ai.predict("gpt-4o", "Answer only with 'xx family' and do not output anything else.")
 )
 ```
 

--- a/example/pandas.ipynb
+++ b/example/pandas.ipynb
@@ -2,17 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Import necessary libraries\n",
-    "import pandas as pd\n",
-    "from openai import OpenAI\n",
-    "from openaivec import VectorizedOpenAI\n",
     "from typing import List\n",
-    "from pydantic import BaseModel\n",
-    "import os"
+    "import os\n",
+    "\n",
+    "import pandas as pd\n",
+    "from pydantic import BaseModel"
    ]
   },
   {
@@ -150,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -169,7 +168,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -190,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -209,7 +208,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -237,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -400,7 +399,7 @@
        "9  strawberry  fraise     いちご    fresa  Erdbeere  fragola  morango  клубника"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `example/pandas.ipynb` files to improve the usage examples and correct the execution counts in the Jupyter notebook.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R115): Added information about the `openaivec.pandas_ext` extension and how to use the `ai.predict` accessor with a `pandas.Series`.

Notebook execution count corrections:

* [`example/pandas.ipynb`](diffhunk://#diff-c47af12116d18cac67df53cd95009199ba7dbe97313cdae467c692213e1bde91L5-R14): Corrected the execution counts for various code cells to ensure consistent and accurate results. [[1]](diffhunk://#diff-c47af12116d18cac67df53cd95009199ba7dbe97313cdae467c692213e1bde91L5-R14) [[2]](diffhunk://#diff-c47af12116d18cac67df53cd95009199ba7dbe97313cdae467c692213e1bde91L153-R152) [[3]](diffhunk://#diff-c47af12116d18cac67df53cd95009199ba7dbe97313cdae467c692213e1bde91L172-R171) [[4]](diffhunk://#diff-c47af12116d18cac67df53cd95009199ba7dbe97313cdae467c692213e1bde91L193-R192) [[5]](diffhunk://#diff-c47af12116d18cac67df53cd95009199ba7dbe97313cdae467c692213e1bde91L212-R211) [[6]](diffhunk://#diff-c47af12116d18cac67df53cd95009199ba7dbe97313cdae467c692213e1bde91L240-R239) [[7]](diffhunk://#diff-c47af12116d18cac67df53cd95009199ba7dbe97313cdae467c692213e1bde91L403-R402)