### PR TITLE
Refactor/pandasext

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=sk-proj-<your-openai-api-key>
+JAVA_HOME=/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home

--- a/example/pandas.ipynb
+++ b/example/pandas.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,28 +18,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# import openaivec.pandas_ext\n",
-    "\n",
-    "This example demonstrates how to integrate the `openaivec.pandas_ext` module with Pandas for text translation tasks. Follow the examples below for single and multi-language translations."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from openaivec import pandas_ext\n",
-    "\n",
-    "pandas_ext.use_openai(\n",
-    "    os.environ[\"OPENAI_API_KEY\"],\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Create a DataFrame\n",
     "\n",
     "We define a list of English entities and create a Pandas DataFrame from this list."
@@ -47,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -71,7 +49,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>entity</th>\n",
+       "      <th>name</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -120,7 +98,7 @@
        "</div>"
       ],
       "text/plain": [
-       "       entity\n",
+       "         name\n",
        "0       apple\n",
        "1      banana\n",
        "2      orange\n",
@@ -133,18 +111,51 @@
        "9  strawberry"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Define a list of entities to translate\n",
-    "entities: List[str] = [\"apple\", \"banana\", \"orange\", \"grape\", \"kiwi\", \"mango\", \"peach\", \"pear\", \"pineapple\", \"strawberry\"]\n",
+    "fruits: List[str] = [\"apple\", \"banana\", \"orange\", \"grape\", \"kiwi\", \"mango\", \"peach\", \"pear\", \"pineapple\", \"strawberry\"]\n",
+    "fruits_df = pd.DataFrame({\"name\": fruits})\n",
+    "fruits_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# import openaivec.pandas_ext\n",
     "\n",
-    "# Create a DataFrame from the entity list\n",
-    "df = pd.DataFrame({\"entity\": entities})\n",
-    "df"
+    "This example demonstrates how to integrate the `openaivec.pandas_ext` module with Pandas for text translation tasks. Follow the examples below for single and multi-language translations.\n",
+    "\n",
+    "If environment variavle `OPENAI_API_KEY` is set, `pandas_ext` automatically use the client `openai.OpenAI`.\n",
+    "\n",
+    "If environment variables `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_API_VERSION` are set, `pandas_ext` automatically use the client `openai.AzureOpenAI`.\n",
+    "\n",
+    "If you must use specific instance of `openai.OpenAI`, please set client with `pandas_ext.use`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openai\n",
+    "from openaivec import pandas_ext\n",
+    "\n",
+    "pandas_ext.use(openai.OpenAI())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Process the columns with OpenAI\n",
+    "Once we load `pandas_ext`, we are able to process with series with simple accessof `pd.Series.ai.predict`."
    ]
   },
   {
@@ -165,7 +176,7 @@
        "7     poire\n",
        "8    ananas\n",
        "9    fraise\n",
-       "dtype: object"
+       "Name: name, dtype: object"
       ]
      },
      "execution_count": 4,
@@ -174,8 +185,8 @@
     }
    ],
    "source": [
-    "# Translate entity to French and add as a new column\n",
-    "s: pd.Series = df.entity.ai.predict(\"gpt-4o-mini\", \"translate to French\")\n",
+    "# Translate name to French and add as a new column\n",
+    "s: pd.Series = fruits_df.name.ai.predict(\"gpt-4o-mini\", \"translate to French\")\n",
     "\n",
     "s"
    ]
@@ -184,12 +195,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Structured Output with pandas_ext"
+    "And embeddings also works with method `pd.Series.ai.embed`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    [0.017625168, -0.016837789, -0.041888542, 0.01...\n",
+       "1    [0.008520956, -0.024025958, -0.029065346, -0.0...\n",
+       "2    [-0.025900742, -0.005591442, -0.0061122794, 0....\n",
+       "3    [-0.038733866, 0.009573344, -0.02065904, -0.00...\n",
+       "4    [-0.005749877, -0.021446224, -0.02598345, 0.02...\n",
+       "5    [0.05547354, -0.008819806, -0.01995101, -0.006...\n",
+       "6    [0.030666627, -0.041978087, -0.01391589, 0.037...\n",
+       "7    [0.023669902, -0.0224248, -0.008767592, 0.0390...\n",
+       "8    [0.02096468, -0.06055253, -0.0029422021, 0.022...\n",
+       "9    [0.020135976, -0.014379032, -0.04067174, -0.02...\n",
+       "Name: name, dtype: object"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e: pd.Series = fruits_df.name.ai.embed(\"text-embedding-3-small\")\n",
+    "\n",
+    "e"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Structured Output with pandas_ext\n",
+    "\n",
+    "Structured output is also available in `pd.Series.ai.predict`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -205,10 +257,10 @@
        "7    en='pear' fr='poire' ja='梨' es='pera' de='Birn...\n",
        "8    en='pineapple' fr='ananas' ja='パイナップル' es='piñ...\n",
        "9    en='strawberry' fr='fraise' ja='いちご' es='fresa...\n",
-       "dtype: object"
+       "Name: name, dtype: object"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -225,18 +277,27 @@
     "    pt: str  # Portuguese\n",
     "    ru: str  # Russian\n",
     "\n",
-    "translations: pd.Series = df.entity.ai.predict(\n",
+    "translations: pd.Series = fruits_df.name.ai.predict(\n",
     "    model_name=\"gpt-4o-mini\",\n",
     "    prompt=\"translate to multiple languages\",\n",
-    "    respnse_format=Translation\n",
+    "    response_format=Translation\n",
     ")\n",
     "\n",
     "translations"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And these values of `pd.Series` are instance of `pydantic.BaseModel`. \n",
+    "\n",
+    "`pd.Series.ai.extract` method can parse each element as `pd.DataFrame`"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -399,13 +460,284 @@
        "9  strawberry  fraise     いちご    fresa  Erdbeere  fragola  morango  клубника"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "translations.ai.extract()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example of Data Enrichment of fruit table\n",
+    "\n",
+    "These interfaces can be seamlessly integreted with `pd.DataFrame` APIs.\n",
+    "\n",
+    "Let's enrich your data with power of LLMs!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>color</th>\n",
+       "      <th>embedding</th>\n",
+       "      <th>translation</th>\n",
+       "      <th>en</th>\n",
+       "      <th>fr</th>\n",
+       "      <th>ja</th>\n",
+       "      <th>es</th>\n",
+       "      <th>de</th>\n",
+       "      <th>it</th>\n",
+       "      <th>pt</th>\n",
+       "      <th>ru</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>apple</td>\n",
+       "      <td>red</td>\n",
+       "      <td>[0.017625168, -0.016837789, -0.041888542, 0.01...</td>\n",
+       "      <td>en='apple' fr='pomme' ja='リンゴ' es='manzana' de...</td>\n",
+       "      <td>apple</td>\n",
+       "      <td>pomme</td>\n",
+       "      <td>リンゴ</td>\n",
+       "      <td>manzana</td>\n",
+       "      <td>Apfel</td>\n",
+       "      <td>mela</td>\n",
+       "      <td>maçã</td>\n",
+       "      <td>яблоко</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>banana</td>\n",
+       "      <td>yellow</td>\n",
+       "      <td>[0.008520956, -0.024025958, -0.029065346, -0.0...</td>\n",
+       "      <td>en='banana' fr='banane' ja='バナナ' es='plátano' ...</td>\n",
+       "      <td>banana</td>\n",
+       "      <td>banane</td>\n",
+       "      <td>バナナ</td>\n",
+       "      <td>plátano</td>\n",
+       "      <td>Banane</td>\n",
+       "      <td>banana</td>\n",
+       "      <td>banana</td>\n",
+       "      <td>банан</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>orange</td>\n",
+       "      <td>orange</td>\n",
+       "      <td>[-0.025900742, -0.005591442, -0.0061122794, 0....</td>\n",
+       "      <td>en='orange' fr='orange' ja='オレンジ' es='naranja'...</td>\n",
+       "      <td>orange</td>\n",
+       "      <td>orange</td>\n",
+       "      <td>オレンジ</td>\n",
+       "      <td>naranja</td>\n",
+       "      <td>Orange</td>\n",
+       "      <td>arancia</td>\n",
+       "      <td>laranja</td>\n",
+       "      <td>апельсин</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>grape</td>\n",
+       "      <td>purple</td>\n",
+       "      <td>[-0.038733866, 0.009573344, -0.02065904, -0.00...</td>\n",
+       "      <td>en='grape' fr='raisin' ja='ぶどう' es='uva' de='T...</td>\n",
+       "      <td>grape</td>\n",
+       "      <td>raisin</td>\n",
+       "      <td>ぶどう</td>\n",
+       "      <td>uva</td>\n",
+       "      <td>Traube</td>\n",
+       "      <td>uva</td>\n",
+       "      <td>uva</td>\n",
+       "      <td>виноград</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>kiwi</td>\n",
+       "      <td>green</td>\n",
+       "      <td>[-0.005749877, -0.021446224, -0.02598345, 0.02...</td>\n",
+       "      <td>en='kiwi' fr='kiwi' ja='キウイ' es='kiwi' de='Kiw...</td>\n",
+       "      <td>kiwi</td>\n",
+       "      <td>kiwi</td>\n",
+       "      <td>キウイ</td>\n",
+       "      <td>kiwi</td>\n",
+       "      <td>Kiwi</td>\n",
+       "      <td>kiwi</td>\n",
+       "      <td>kiwi</td>\n",
+       "      <td>киви</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>mango</td>\n",
+       "      <td>yellow/orange</td>\n",
+       "      <td>[0.05547354, -0.008819806, -0.01995101, -0.006...</td>\n",
+       "      <td>en='mango' fr='mangue' ja='マンゴー' es='mango' de...</td>\n",
+       "      <td>mango</td>\n",
+       "      <td>mangue</td>\n",
+       "      <td>マンゴー</td>\n",
+       "      <td>mango</td>\n",
+       "      <td>Mango</td>\n",
+       "      <td>mango</td>\n",
+       "      <td>manga</td>\n",
+       "      <td>манго</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>peach</td>\n",
+       "      <td>pink</td>\n",
+       "      <td>[0.030666627, -0.041978087, -0.01391589, 0.037...</td>\n",
+       "      <td>en='peach' fr='pêche' ja='桃' es='durazno' de='...</td>\n",
+       "      <td>peach</td>\n",
+       "      <td>pêche</td>\n",
+       "      <td>桃</td>\n",
+       "      <td>durazno</td>\n",
+       "      <td>Pfirsich</td>\n",
+       "      <td>pesca</td>\n",
+       "      <td>pêssego</td>\n",
+       "      <td>персик</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>pear</td>\n",
+       "      <td>green</td>\n",
+       "      <td>[0.023707643, -0.022397757, -0.008799582, 0.03...</td>\n",
+       "      <td>en='pear' fr='poire' ja='梨' es='pera' de='Birn...</td>\n",
+       "      <td>pear</td>\n",
+       "      <td>poire</td>\n",
+       "      <td>梨</td>\n",
+       "      <td>pera</td>\n",
+       "      <td>Birne</td>\n",
+       "      <td>pera</td>\n",
+       "      <td>pera</td>\n",
+       "      <td>груша</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>pineapple</td>\n",
+       "      <td>yellow/brown</td>\n",
+       "      <td>[0.021006476, -0.060446374, -0.002942336, 0.02...</td>\n",
+       "      <td>en='pineapple' fr='ananas' ja='パイナップル' es='piñ...</td>\n",
+       "      <td>pineapple</td>\n",
+       "      <td>ananas</td>\n",
+       "      <td>パイナップル</td>\n",
+       "      <td>piña</td>\n",
+       "      <td>Ananas</td>\n",
+       "      <td>ananas</td>\n",
+       "      <td>abacaxi</td>\n",
+       "      <td>ананас</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>strawberry</td>\n",
+       "      <td>red</td>\n",
+       "      <td>[0.020135976, -0.014379032, -0.04067174, -0.02...</td>\n",
+       "      <td>en='strawberry' fr='fraise' ja='いちご' es='fresa...</td>\n",
+       "      <td>strawberry</td>\n",
+       "      <td>fraise</td>\n",
+       "      <td>いちご</td>\n",
+       "      <td>fresa</td>\n",
+       "      <td>Erdbeere</td>\n",
+       "      <td>fragola</td>\n",
+       "      <td>morango</td>\n",
+       "      <td>клубника</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         name          color  \\\n",
+       "0       apple            red   \n",
+       "1      banana         yellow   \n",
+       "2      orange         orange   \n",
+       "3       grape         purple   \n",
+       "4        kiwi          green   \n",
+       "5       mango  yellow/orange   \n",
+       "6       peach           pink   \n",
+       "7        pear          green   \n",
+       "8   pineapple   yellow/brown   \n",
+       "9  strawberry            red   \n",
+       "\n",
+       "                                           embedding  \\\n",
+       "0  [0.017625168, -0.016837789, -0.041888542, 0.01...   \n",
+       "1  [0.008520956, -0.024025958, -0.029065346, -0.0...   \n",
+       "2  [-0.025900742, -0.005591442, -0.0061122794, 0....   \n",
+       "3  [-0.038733866, 0.009573344, -0.02065904, -0.00...   \n",
+       "4  [-0.005749877, -0.021446224, -0.02598345, 0.02...   \n",
+       "5  [0.05547354, -0.008819806, -0.01995101, -0.006...   \n",
+       "6  [0.030666627, -0.041978087, -0.01391589, 0.037...   \n",
+       "7  [0.023707643, -0.022397757, -0.008799582, 0.03...   \n",
+       "8  [0.021006476, -0.060446374, -0.002942336, 0.02...   \n",
+       "9  [0.020135976, -0.014379032, -0.04067174, -0.02...   \n",
+       "\n",
+       "                                         translation          en      fr  \\\n",
+       "0  en='apple' fr='pomme' ja='リンゴ' es='manzana' de...       apple   pomme   \n",
+       "1  en='banana' fr='banane' ja='バナナ' es='plátano' ...      banana  banane   \n",
+       "2  en='orange' fr='orange' ja='オレンジ' es='naranja'...      orange  orange   \n",
+       "3  en='grape' fr='raisin' ja='ぶどう' es='uva' de='T...       grape  raisin   \n",
+       "4  en='kiwi' fr='kiwi' ja='キウイ' es='kiwi' de='Kiw...        kiwi    kiwi   \n",
+       "5  en='mango' fr='mangue' ja='マンゴー' es='mango' de...       mango  mangue   \n",
+       "6  en='peach' fr='pêche' ja='桃' es='durazno' de='...       peach   pêche   \n",
+       "7  en='pear' fr='poire' ja='梨' es='pera' de='Birn...        pear   poire   \n",
+       "8  en='pineapple' fr='ananas' ja='パイナップル' es='piñ...   pineapple  ananas   \n",
+       "9  en='strawberry' fr='fraise' ja='いちご' es='fresa...  strawberry  fraise   \n",
+       "\n",
+       "       ja       es        de       it       pt        ru  \n",
+       "0     リンゴ  manzana     Apfel     mela     maçã    яблоко  \n",
+       "1     バナナ  plátano    Banane   banana   banana     банан  \n",
+       "2    オレンジ  naranja    Orange  arancia  laranja  апельсин  \n",
+       "3     ぶどう      uva    Traube      uva      uva  виноград  \n",
+       "4     キウイ     kiwi      Kiwi     kiwi     kiwi      киви  \n",
+       "5    マンゴー    mango     Mango    mango    manga     манго  \n",
+       "6       桃  durazno  Pfirsich    pesca  pêssego    персик  \n",
+       "7       梨     pera     Birne     pera     pera     груша  \n",
+       "8  パイナップル     piña    Ananas   ananas  abacaxi    ананас  \n",
+       "9     いちご    fresa  Erdbeere  fragola  morango  клубника  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fruits_df.assign(\n",
+    "    color=lambda df: df.name.ai.predict(\"gpt-4o-mini\", \"Return the color is the fruit\"),\n",
+    "    embedding=lambda df: df.name.ai.embed(\"text-embedding-3-small\"),\n",
+    "    translation=lambda df: df.name.ai.predict(\"gpt-4o-mini\", \"translate to multple languages\", response_format=Translation)\n",
+    ").pipe(\n",
+    "    lambda df: df.join(df.translation.ai.extract())    \n",
+    ")"
    ]
   },
   {
@@ -432,7 +764,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.1"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/openaivec/pandas_ext.py
+++ b/openaivec/pandas_ext.py
@@ -9,6 +9,7 @@ from openaivec.embedding import EmbeddingLLM, EmbeddingOpenAI
 from openaivec.vectorize import VectorizedLLM, VectorizedOpenAI
 
 __all__ = [
+    "use",
     "use_openai",
     "use_azure_openai",
 ]
@@ -17,6 +18,14 @@ __all__ = [
 T = TypeVar("T")
 
 _client: OpenAI | None = None
+
+
+def use(client: OpenAI) -> None:
+    """
+    Set the OpenAI client to use for OpenAI.
+    """
+    global _client
+    _client = client
 
 
 def use_openai(api_key: str) -> None:
@@ -75,13 +84,13 @@ class OpenAIVecSeriesAccessor:
     def __init__(self, series_obj: pd.Series):
         self._obj = series_obj
 
-    def predict(self, model_name: str, prompt: str, respnse_format: Type[T] = str, batch_size: int = 128) -> pd.Series:
+    def predict(self, model_name: str, prompt: str, response_format: Type[T] = str, batch_size: int = 128) -> pd.Series:
         client: VectorizedLLM = VectorizedOpenAI(
             client=get_openai_client(),
             model_name=model_name,
             system_message=prompt,
             is_parallel=True,
-            response_format=respnse_format,
+            response_format=response_format,
             temperature=0,
             top_p=1,
         )

--- a/openaivec/pandas_ext.py
+++ b/openaivec/pandas_ext.py
@@ -21,7 +21,7 @@ _client: OpenAI | None = None
 
 def use_openai(api_key: str) -> None:
     """
-    Set the OpenAI API key to use for OpenAI and Azure OpenAI.
+    Set the OpenAI API key to use for OpenAI.
     """
     global _client
     _client = OpenAI(api_key=api_key)
@@ -89,6 +89,7 @@ class OpenAIVecSeriesAccessor:
         return pd.Series(
             client.predict_minibatch(self._obj.tolist(), batch_size=batch_size),
             index=self._obj.index,
+            name=self._obj.name,
         )
 
     def embed(self, model_name: str, batch_size: int = 128) -> pd.Series:
@@ -100,6 +101,7 @@ class OpenAIVecSeriesAccessor:
         return pd.Series(
             client.embed_minibatch(self._obj.tolist(), batch_size=batch_size),
             index=self._obj.index,
+            name=self._obj.name,
         )
 
     def extract(self) -> pd.DataFrame:

--- a/openaivec/pandas_ext.py
+++ b/openaivec/pandas_ext.py
@@ -5,7 +5,7 @@ import pandas as pd
 from openai import AzureOpenAI, OpenAI
 from pydantic import BaseModel
 
-from openaivec.embedding import EmbeddingOpenAI
+from openaivec.embedding import EmbeddingLLM, EmbeddingOpenAI
 from openaivec.vectorize import VectorizedLLM, VectorizedOpenAI
 
 __all__ = [
@@ -92,7 +92,7 @@ class OpenAIVecSeriesAccessor:
         )
 
     def embed(self, model_name: str, batch_size: int = 128) -> pd.Series:
-        client: VectorizedLLM = EmbeddingOpenAI(
+        client: EmbeddingLLM = EmbeddingOpenAI(
             client=get_openai_client(),
             model_name=model_name,
         )

--- a/openaivec/vectorize.py
+++ b/openaivec/vectorize.py
@@ -115,7 +115,7 @@ class VectorizedOpenAI(VectorizedLLM, Generic[T]):
 
         class MessageT(BaseModel):
             id: int
-            body: response_format
+            body: response_format # type: ignore
 
         class ResponseT(BaseModel):
             assistant_messages: List[MessageT]


### PR DESCRIPTION
This pull request introduces several updates to the `openaivec` package, including new functionality, refactoring, and minor fixes. The key changes are grouped into new functionality, refactoring, and minor fixes.

### New Functionality:
* Added `EmbeddingLLM` abstract base class to `openaivec/embedding.py` to provide a standard interface for embedding models. The `EmbeddingOpenAI` class now inherits from this base class. [[1]](diffhunk://#diff-6ee771a1866417de265e29de12e978ad24c948b0629959c238f56f9f5720be38R1) [[2]](diffhunk://#diff-6ee771a1866417de265e29de12e978ad24c948b0629959c238f56f9f5720be38L10-R33)
* Introduced `use` function in `openaivec/pandas_ext.py` to set the OpenAI client globally.

### Refactoring:
* Updated `EmbeddingOpenAI` to include a new `is_parallel` attribute and modified the `embed_minibatch` method to use `map_unique_minibatch_parallel` when `is_parallel` is `True`.
* Corrected the import statements in `openaivec/pandas_ext.py` to include `EmbeddingLLM`.
* Fixed a typo in the `predict` method of `OpenAIVecSeriesAccessor` class in `openaivec/pandas_ext.py` and added the `name` attribute to the returned `pd.Series` in `predict` and `embed` methods.

### Minor Fixes:
* Added `OPENAI_API_KEY` and `JAVA_HOME` environment variables to `.env.example`.
* Added `# type: ignore` comment to suppress type-checking error in `request` method in `openaivec/vectorize.py`.